### PR TITLE
Add options for EFS encryption and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The following arguments are supported:
 - ``name`` - (Required) An identifier for your file system.
 - ``subnets`` - (Required) A list of subnet ids where mount targets will be created.
 - ``vpc_id`` - (Required) The VPC ID the security groups will be.
+- ``encrypted`` - (Optional) If true, the file system will be encrypted at rest
+- ``kms_key_id`` - The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `encrypted = true`
+- ``tags`` - (Optional) A mapping of tags to apply to resources
 
 ## Attribute Reference
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -1,14 +1,33 @@
 variable "name" {
-  type = string
+  type        = string
   description = "(Required) The reference_name of your file system. Also, used in tags."
 }
 
 variable "subnets" {
-  type = list
-  description = "(Required) A list of subnet ids where mount targets will be." 
+  type        = list
+  description = "(Required) A list of subnet ids where mount targets will be."
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "(Required) The VPC ID where NFS security groups will be."
+}
+
+variable "encrypted" {
+  description = "(Optional) If true, the disk will be encrypted"
+  default     = false
+  type        = bool
+}
+
+
+variable "kms_key_id" {
+  type        = string
+  description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `encrypted = true`"
+  default     = ""
+}
+
+variable "tags" {
+  description = "A mapping of tags to apply to resources"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
* Add missing options to enable encryption at rest and provide KMS key for it. If key is omitted then default AWS KMS key will be used.
* Add `tags` option to provide additional optional tags to resources.
* Terraform format fixes