### PR TITLE
fixing deprecated map function, added parameters

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -19,7 +19,6 @@ variable "encrypted" {
   type        = bool
 }
 
-
 variable "kms_key_id" {
   type        = string
   description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `encrypted = true`"
@@ -36,6 +35,12 @@ variable "cidr_blocks" {
   type        = list
   description = "(Optional) A list of CIDR blocks to be allowed access to the mount points"
   default     = []
+}
+
+variable "transition_to_ia" {
+  description = "Indicates how long it takes to transition files to the IA storage class"
+  type        = string
+  default     = ""
 }
 
 variable "tags" {

--- a/inputs.tf
+++ b/inputs.tf
@@ -26,10 +26,16 @@ variable "kms_key_id" {
   default     = ""
 }
 
+variable "throughput_mode" {
+  type        = string
+  description = "thoughput mode"
+  default     = "bursting"
+}
+
 variable "cidr_blocks" {
   type        = list
   description = "(Optional) A list of CIDR blocks to be allowed access to the mount points"
-  default     = ""
+  default     = []
 }
 
 variable "tags" {

--- a/inputs.tf
+++ b/inputs.tf
@@ -26,6 +26,12 @@ variable "kms_key_id" {
   default     = ""
 }
 
+variable "cidr_blocks" {
+  type        = list
+  description = "(Optional) A list of CIDR blocks to be allowed access to the mount points"
+  default     = ""
+}
+
 variable "tags" {
   description = "A mapping of tags to apply to resources"
   type        = map(string)

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_efs_file_system" "this" {
   encrypted  = var.encrypted
   kms_key_id = var.kms_key_id
   
-  throughput_mode = "elastic"
+  throughput_mode = var.throughput_mode
 
   tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)
 }
@@ -46,6 +46,7 @@ resource "aws_security_group_rule" "nfs_egress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.mount_target_client.id
   source_security_group_id = aws_security_group.mount_target.id
+  cidr_blocks              = var.cidr_blocks
 }
 
 resource "aws_security_group" "mount_target" {
@@ -69,5 +70,6 @@ resource "aws_security_group_rule" "nfs_ingress" {
   to_port                  = 2049
   protocol                 = "tcp"
   security_group_id        = aws_security_group.mount_target.id
-  source_security_group_id = aws_security_group.mount_target_client.id
+  source_security_group_id = var.cidr_blocks == [] ? aws_security_group.mount_target_client.id : null
+  cidr_blocks              = var.cidr_blocks == [] ? null: var.cidr_blocks
 }

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_efs_file_system" "this" {
   
   lifecycle_policy {
     transition_to_ia = var.transition_to_ia == "" ? null : var.transition_to_ia
+    transition_to_primary_storage_class = "AFTER_1_ACCESS"
   }
   
   tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)

--- a/main.tf
+++ b/main.tf
@@ -28,8 +28,10 @@ resource "aws_security_group" "mount_target_client" {
   depends_on = [aws_efs_mount_target.this]
 
   tags = merge(
-    map("Name", "${var.name}-mount-target-client"),
-    map("terraform", "true"),
+    {
+      Name = "${var.name}-mount-target-client",
+      terraform = true
+    },
     var.tags,
   )
 }
@@ -50,9 +52,11 @@ resource "aws_security_group" "mount_target" {
   vpc_id      = var.vpc_id
 
   tags = merge(
-    map("Name", "${var.name}-mount-target"),
-    map("terraform", "true"),
-    var.tags,
+    {
+      Name = "${var.name}-mount-target",
+      terraform = true
+    },
+    var.tags
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_efs_file_system" "this" {
   encrypted  = var.encrypted
   kms_key_id = var.kms_key_id
 
-  tags = merge({Name = ${var.name}, CreationToken = ${random_id.creation_token.hex}, terraform = true}, var.tags)
+  tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,11 @@ resource "aws_efs_file_system" "this" {
   kms_key_id = var.kms_key_id
   
   throughput_mode = var.throughput_mode
-
+  
+  lifecycle_policy {
+    transition_to_ia = var.transition_to_ia == "" ? null : var.transition_to_ia
+  }
+  
   tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,6 @@ resource "aws_security_group_rule" "nfs_egress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.mount_target_client.id
   source_security_group_id = aws_security_group.mount_target.id
-  cidr_blocks              = var.cidr_blocks
 }
 
 resource "aws_security_group" "mount_target" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_efs_file_system" "this" {
   
   lifecycle_policy {
     transition_to_ia = var.transition_to_ia == "" ? null : var.transition_to_ia
-    transition_to_primary_storage_class = "AFTER_1_ACCESS"
+    transition_to_primary_storage_class = var.transition_to_ia == "" ? null : "AFTER_1_ACCESS"
   }
   
   tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)

--- a/main.tf
+++ b/main.tf
@@ -9,14 +9,7 @@ resource "aws_efs_file_system" "this" {
   encrypted  = var.encrypted
   kms_key_id = var.kms_key_id
 
-  tags = merge(
-    {
-      "Name" = ${var.name},
-      "CreationToken" = ${random_id.creation_token.hex},
-      "terraform" = true
-    },
-    var.tags,
-  )
+  tags = merge({Name = ${var.name}, CreationToken = ${random_id.creation_token.hex}, terraform = true}, var.tags)
 }
 
 resource "aws_efs_mount_target" "this" {

--- a/main.tf
+++ b/main.tf
@@ -10,9 +10,11 @@ resource "aws_efs_file_system" "this" {
   kms_key_id = var.kms_key_id
 
   tags = merge(
-    map("Name", var.name),
-    map("CreationToken", random_id.creation_token.hex),
-    map("terraform", "true"),
+    {
+      Name = $(var.name),
+      CreationToken = $(random_id.creation_token.hex),
+      terraform = true
+    },
     var.tags,
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,9 @@ resource "aws_efs_file_system" "this" {
 
   tags = merge(
     {
-      Name = ${var.name},
-      CreationToken = ${random_id.creation_token.hex},
-      terraform = true
+      "Name" = ${var.name},
+      "CreationToken" = ${random_id.creation_token.hex},
+      "terraform" = true
     },
     var.tags,
   )

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,9 @@ resource "aws_efs_file_system" "this" {
   
   lifecycle_policy {
     transition_to_ia = var.transition_to_ia == "" ? null : var.transition_to_ia
+  }
+
+  lifecycle_policy {
     transition_to_primary_storage_class = var.transition_to_ia == "" ? null : "AFTER_1_ACCESS"
   }
   

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ resource "aws_efs_file_system" "this" {
 
   encrypted  = var.encrypted
   kms_key_id = var.kms_key_id
+  
+  throughput_mode = "elastic"
 
   tags = merge({Name = "${var.name}", CreationToken = "${random_id.creation_token.hex}", terraform = true}, var.tags)
 }

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ resource "aws_efs_file_system" "this" {
 
   tags = merge(
     {
-      Name = $(var.name),
-      CreationToken = $(random_id.creation_token.hex),
+      Name = ${var.name},
+      CreationToken = ${random_id.creation_token.hex},
       terraform = true
     },
     var.tags,


### PR DESCRIPTION
fixed deprecated map() function still in use. Added more input variables: thoughout_mode, and cidr_blocks as option to assign origin to ingress security rule (common scenario when using EFS with EKS)